### PR TITLE
Add .pruneKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,30 @@ superagent
 );
 ```
 
+## .pruneKey(callback)
+
+This function takes a function which accepts a cache key object and returns a modified cache key object. This allows you to change what is used to track items in the cache (above-and-beyond what is provided by `.pruneQuery` and `.pruneHeader`).
+
+#### Arguments
+
+* callback: a function which takes a key object
+
+#### Example
+
+```javascript
+//the cache key can be any object but modifying the existing one
+//can allow you to do things like modify the URL used as the cache key
+superagent
+  .get(uri)
+  .use(superagentCache)
+  .set(options)
+  .pruneKey(key => ({...key, uri: key.uri.replace("https:", "http:")}))
+  .end(function (error, response){
+    // handle response
+  }
+);
+```
+
 ## .expiration(seconds)
 
 Use this function when you need to override your `cache`'s `defaultExpiration` property for a particular cache entry.

--- a/index.js
+++ b/index.js
@@ -44,6 +44,15 @@ module.exports = function(cache, defaults){
     }
 
     /**
+     * Modify the cache key before it's generated.
+     * @param {function} pruneKey
+     */
+    Request.pruneKey = function(pruneKey){
+      props.pruneKey = pruneKey;
+      return Request;
+    }
+
+    /**
      * Execute some logic on superagent's http response object before caching and returning it
      * @param {function} prune
      */

--- a/test/server/spec.js
+++ b/test/server/spec.js
@@ -171,6 +171,22 @@ describe('superagentCache', function(){
       );
     });
 
+    it('.get() .pruneKey() .end() should query with all params but create a key without the indicated params', function (done) {
+      superagent
+        .get('localhost:3007/one')
+        .use(superagentCache)
+        .pruneKey(function (key) {
+          key.uri = 'localhost:3007/false';
+          return key;
+        })
+        .end(function (err, response, key){
+          expect(key.indexOf('/one')).toBe(-1);
+          expect(key.indexOf('/false')).toBeGreaterThan(-1);
+          done();
+        }
+      );
+    });
+
     it('.get() .query(object) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')

--- a/utils.js
+++ b/utils.js
@@ -14,12 +14,16 @@ module.exports = {
       cleanParams = (props.pruneQuery) ? this.pruneObj(this.cloneObject(params), props.pruneQuery) : params;
       cleanOptions = (props.pruneHeader) ? this.pruneObj(this.cloneObject(options), props.pruneHeader, true) : options;
     }
-    return JSON.stringify({
+    var key = {
       method: req.method,
       uri: req.url,
       params: cleanParams || params || null,
       options: cleanOptions || options || null
-    });
+    };
+    if (props.pruneKey) {
+      key = props.pruneKey(key);
+    }
+    return JSON.stringify(key);
   },
 
   /**
@@ -166,6 +170,7 @@ module.exports = {
       prune: d.prune,
       pruneQuery: d.pruneQuery,
       pruneHeader: d.pruneHeader,
+      pruneKey: d.pruneKey,
       responseProp: d.responseProp,
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,


### PR DESCRIPTION
This adds a new function for modifying the key used to cache responses, above-and-beyond what `.pruneQuery` and `.pruneHeader` offer. This makes it possible to modify the URI in the key.

Test plan:
I ran `npm test` and it passed.